### PR TITLE
Update src paths and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ Dự án **TN4** được phát triển nhằm thu thập và xử lý dữ li�
 
 Kích hoạt môi trường ảo (nếu chưa), sau đó chạy:
 ```bash
-python TN4/app.py
+python src/app.py
 ```
 Ứng dụng sẽ khởi động tại địa chỉ `http://localhost:58888` ở chế độ mặc định.
 
 ## Cấu trúc thư mục chính
 
 ```
-src/        # mã nguồn của ứng dụng (thư mục TN4 hiện tại)
+src/        # mã nguồn của ứng dụng
 templates/  # các tệp giao diện HTML
 static/     # tài nguyên tĩnh như CSS, JS, hình ảnh
 database/   # file cấu hình và dữ liệu mẫu

--- a/src/app.py
+++ b/src/app.py
@@ -91,7 +91,7 @@ stream_handler.setFormatter(formatter)
 logger.addHandler(stream_handler)
 
 # File handler (log file, split at midnight everyday)
-file_handler = TimedRotatingFileHandler('/home/jetson/project/TN4/database/log/log_cico_everyday.log', when="midnight", interval=1)
+file_handler = TimedRotatingFileHandler('/home/jetson/project/src/database/log/log_cico_everyday.log', when="midnight", interval=1)
 file_handler.setFormatter(formatter)
 file_handler.setLevel(logging.DEBUG)
 logger.addHandler(file_handler)
@@ -116,7 +116,7 @@ app.secret_key = '4s$eJ#8dLpRtYkMnCbV2gX1fA3h'
 
 
 # Đường dẫn tới tệp JSON
-FILE_PATH_SETUP = "/home/jetson/project/TN4/database/data_setup/data_setup.json"
+FILE_PATH_SETUP = "/home/jetson/project/src/database/data_setup/data_setup.json"
 # Hàm để đọc dữ liệu từ tệp JSON
 def load_data_setup():
     with open(FILE_PATH_SETUP, "r") as file_setup:
@@ -158,12 +158,12 @@ device_requests = {}
 
 # Cơ sở dữ liệu người dùng lưu trong file JSON
 # Đường dẫn đến file JSON chứa thông tin server
-SERVER_FILE = '/home/jetson/project/TN4/database/data_setup/servers.json'
-DATA_FILE = '/home/jetson/project/TN4/database/data_setup/data_setup.json'
+SERVER_FILE = '/home/jetson/project/src/database/data_setup/servers.json'
+DATA_FILE = '/home/jetson/project/src/database/data_setup/data_setup.json'
 # Đường dẫn tới file JSON lưu lịch sử số lượng request của các thiết bị
-REQUEST_HISTORY_FILE = '/home/jetson/project/TN4/database/data_setup/request_history.json'
+REQUEST_HISTORY_FILE = '/home/jetson/project/src/database/data_setup/request_history.json'
 # Đường dẫn đến file users.json
-USER_FILE = os.path.join(os.getcwd(), '/home/jetson/project/TN4/database/data_setup/users.json')
+USER_FILE = os.path.join(os.getcwd(), '/home/jetson/project/src/database/data_setup/users.json')
 # Biến toàn cục lưu trữ kết quả số lượng thiết bị online, offline và tổng
 device_status = {
     "online": 0,
@@ -391,7 +391,7 @@ def log_access(username, ip):
 
 # Hàm đọc danh sách các menu và quyền từ file JSON
 def load_permission_menu():
-    with open("/home/jetson/project/TN4/database/data_setup/permissions.json", "r", encoding="utf-8") as f:
+    with open("/home/jetson/project/src/database/data_setup/permissions.json", "r", encoding="utf-8") as f:
         return json.load(f)
 def get_base_context(template_title="Trang"):
     username = session.get("username")
@@ -414,7 +414,7 @@ def inject_menu():
         return {"menu_items": [], "camera_items": []}
 
 def update_user_permissions_in_file(users):
-    with open('/home/jetson/project/TN4/database/data_setup/users.json', 'w') as f:
+    with open('/home/jetson/project/src/database/data_setup/users.json', 'w') as f:
         json.dump(users, f, indent=4)
 def update_user_permissions(username, new_permissions):
     users = load_users()
@@ -422,7 +422,7 @@ def update_user_permissions(username, new_permissions):
         if user['username'] == username:
             user['permissions'] = new_permissions
             break
-    with open('/home/jetson/project/TN4/database/data_setup/users.json', 'w') as f:
+    with open('/home/jetson/project/src/database/data_setup/users.json', 'w') as f:
         json.dump(users, f)
 def save_to_file(data, filename= './database/data_setup/users.json'):
     # Mở file JSON và ghi lại danh sách người dùng đã được cập nhật


### PR DESCRIPTION
## Summary
- update absolute paths in `app.py` to use `src` directory
- fix README to reference running `python src/app.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6856cdfbe794832b8951335173187364