### PR TITLE
Remove hardcoded secret

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -112,7 +112,6 @@ data_queue = queue.Queue()
 
 
 # Khóa bí mật để mã hóa session
-app.secret_key = '4s$eJ#8dLpRtYkMnCbV2gX1fA3h'
 # app.config.from_object(Config)
 # app.register_blueprint(main)
 


### PR DESCRIPTION
## Summary
- keep SECRET_KEY config loaded from environment
- remove obsolete hardcoded secret value

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68578b7c44cc832bb5511434610e52d6