### PR TITLE
Use env variables for API URLs

### DIFF
--- a/src/.env
+++ b/src/.env
@@ -11,3 +11,5 @@ INFLUXDB_DATABASE=ats_data
 MQTT_BROKER_ADDRESS=10.16.40.110
 MQTT_PORT=1883
 MQTT_TOPIC=PLC/LOGO/+
+API_URL=http://10.50.41.18:58185/api/Farm/postbiohistory
+API_URL_CICO=https://10.50.41.18:58187/api/Farm/postbiohistory

--- a/src/data_processor.py
+++ b/src/data_processor.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import cv2
 import json
 import threading
@@ -11,8 +12,8 @@ import base64
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 # API chính
-url        = 'http://10.50.41.18:58185/api/Farm/postbiohistory' 
-url_cico   = 'https://10.50.41.18:58187/api/Farm/postbiohistory'
+url = os.getenv("API_URL")
+url_cico = os.getenv("API_URL_CICO")
 link = "./database/data_setup/"
 file = "data_setup.json"
 
@@ -71,9 +72,11 @@ def process_data(data):
             }
 
             try:
-                r = requests.post("http://10.50.41.18:58185/api/Farm/postbiohistory",
-                                  json.dumps(data),
-                                  headers={'Content-type': 'application/json', 'Accept': 'text/plain'})
+                r = requests.post(
+                    url,
+                    json.dumps(data),
+                    headers={"Content-type": "application/json", "Accept": "text/plain"},
+                )
                 code = r.status_code
                 response_text = r.text
             except requests.RequestException as e:


### PR DESCRIPTION
## Summary
- read API URLs from environment variables in `data_processor`
- record API URL configuration values in `.env`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68578c1f3d08832bb382dfcf48d878eb