### PR TITLE
Add tests for MQTT and utility functions

### DIFF
--- a/tests/test_data_processor.py
+++ b/tests/test_data_processor.py
@@ -1,0 +1,78 @@
+import os
+import json
+import sys
+import types
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+# Stub external modules before importing module
+sys.modules.setdefault('cv2', types.SimpleNamespace(VideoCapture=lambda *a, **k: None, imencode=lambda *a, **k: (True, b'')))
+urllib3_stub = types.ModuleType('urllib3')
+urllib3_stub.exceptions = types.SimpleNamespace(InsecureRequestWarning=Exception)
+sys.modules.setdefault('urllib3', urllib3_stub)
+sys.modules.setdefault('urllib3.exceptions', urllib3_stub.exceptions)
+class RequestsStub(types.ModuleType):
+    def __init__(self):
+        super().__init__('requests')
+        self.packages = types.SimpleNamespace(urllib3=types.SimpleNamespace(disable_warnings=lambda *a, **k: None))
+    def post(self, *a, **k):
+        pass
+
+sys.modules.setdefault('requests', RequestsStub())
+
+import data_processor
+
+class DummyResponse:
+    def __init__(self, status_code=200, text='OK'):
+        self.status_code = status_code
+        self.text = text
+
+class DummyCap:
+    def read(self):
+        return True, 'frame'
+    def release(self):
+        pass
+
+
+def setup_tmp_json(tmp_path):
+    data = {
+        "chipid": {
+            "chip123": {
+                "uv1": {
+                    "mac_address": "AA:BB",
+                    "camera": "0",
+                    "timer": 5
+                },
+                "about": {"ip": "old", "version": "v1"}
+            }
+        }
+    }
+    path = tmp_path / "data_setup.json"
+    path.write_text(json.dumps(data))
+    return path
+
+def test_process_data_success(monkeypatch, tmp_path):
+    json_path = setup_tmp_json(tmp_path)
+    monkeypatch.setattr(data_processor, "link", str(tmp_path) + "/")
+    monkeypatch.setattr(data_processor, "file", "data_setup.json")
+    monkeypatch.setattr(data_processor.cv2, "VideoCapture", lambda cam: DummyCap())
+    monkeypatch.setattr(data_processor.cv2, "imencode", lambda ext, img: (True, b"img"))
+    monkeypatch.setattr(data_processor.requests, "post", lambda *a, **kw: DummyResponse())
+
+    data = {"idchip": "chip123", "name": "uv1", "status": "start", "ip": "1.2.3.4", "version": "v2"}
+    result = data_processor.process_data(data)
+
+    assert result == {"status_code": 200, "response_text": "OK"}
+    updated = json.loads(json_path.read_text())
+    assert updated["chipid"]["chip123"]["about"]["ip"] == "1.2.3.4"
+    assert updated["chipid"]["chip123"]["about"]["version"] == "v2"
+
+def test_process_data_invalid_id(monkeypatch, tmp_path):
+    setup_tmp_json(tmp_path)
+    monkeypatch.setattr(data_processor, "link", str(tmp_path) + "/")
+    monkeypatch.setattr(data_processor, "file", "data_setup.json")
+
+    data = {"idchip": "unknown", "name": "uv1", "status": "start", "ip": "1", "version": "v"}
+    result = data_processor.process_data(data)
+    assert result["status_code"] is None
+    assert "ID chip" in result["error"]

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import json
+import types
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+# Stub paho.mqtt.client before import
+class DummyClient:
+    def __init__(self, *a, **k):
+        self.on_message = None
+    def connect(self, *a, **k):
+        pass
+    def subscribe(self, *a, **k):
+        pass
+    def loop_forever(self):
+        pass
+
+mqtt_stub = types.SimpleNamespace(Client=DummyClient, MQTTv311=0)
+sys.modules.setdefault('paho', types.ModuleType('paho'))
+sys.modules.setdefault('paho.mqtt', types.ModuleType('paho.mqtt'))
+sys.modules.setdefault('paho.mqtt.client', mqtt_stub)
+
+import mqtt
+
+class DummyMessage:
+    def __init__(self, payload):
+        self.payload = payload
+
+
+def test_on_message_prints(capsys):
+    data = {
+        "state": {
+            "reported": {
+                "P1": {"desc": "d1", "value": [1]},
+                "P2": {"desc": "d2", "value": [2]},
+                "$logotime": "now"
+            }
+        }
+    }
+    msg = DummyMessage(json.dumps(data).encode())
+    mqtt.on_message(None, None, msg)
+    captured = capsys.readouterr()
+    assert "P1 - d1: 1" in captured.out
+    assert "P2 - d2: 2" in captured.out
+    assert "Logotime: now" in captured.out

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,124 @@
+import os
+import sys
+import json
+import socket
+import types
+import codecs
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+# Stub external modules before importing app
+sys.modules.setdefault('eventlet', types.SimpleNamespace(monkey_patch=lambda: None))
+cv2_stub = types.SimpleNamespace(VideoCapture=lambda *a, **k: None, imencode=lambda *a, **k: (True, b''))
+sys.modules.setdefault('cv2', cv2_stub)
+class DummyClient:
+    def __init__(self, *a, **k):
+        self.on_message = None
+    def connect(self, *a, **k):
+        pass
+    def subscribe(self, *a, **k):
+        pass
+    def loop_forever(self):
+        pass
+mqtt_stub = types.SimpleNamespace(Client=DummyClient, MQTTv311=0)
+sys.modules.setdefault('paho', types.ModuleType('paho'))
+sys.modules.setdefault('paho.mqtt', types.ModuleType('paho.mqtt'))
+sys.modules.setdefault('paho.mqtt.client', mqtt_stub)
+flask_stub = types.SimpleNamespace(Flask=lambda *a, **k: types.SimpleNamespace(), make_response=lambda *a, **k: None,
+                                    render_template=lambda *a, **k: None, redirect=lambda *a, **k: None,
+                                    send_from_directory=lambda *a, **k: None, url_for=lambda *a, **k: '',
+                                    request=None, session=None, flash=lambda *a, **k: None,
+                                    send_file=lambda *a, **k: None, jsonify=lambda *a, **k: None)
+sys.modules.setdefault('flask', flask_stub)
+sys.modules.setdefault('flask_socketio', types.SimpleNamespace(SocketIO=lambda *a, **k: types.SimpleNamespace(on=lambda *a, **k: lambda f: f, emit=lambda *a, **k: None)))
+sys.modules.setdefault('influxdb', types.SimpleNamespace(InfluxDBClient=lambda *a, **k: None))
+sys.modules.setdefault('ats_socket', types.SimpleNamespace(start_ats_socketio_listener=lambda *a, **k: None))
+sys.modules.setdefault('dotenv', types.SimpleNamespace(load_dotenv=lambda *a, **k: None))
+urllib3_stub = types.ModuleType('urllib3')
+urllib3_stub.exceptions = types.SimpleNamespace(InsecureRequestWarning=Exception)
+sys.modules.setdefault('urllib3', urllib3_stub)
+sys.modules.setdefault('urllib3.exceptions', urllib3_stub.exceptions)
+sys.modules.setdefault('werkzeug', types.ModuleType('werkzeug'))
+sys.modules.setdefault('werkzeug.utils', types.SimpleNamespace(secure_filename=lambda *a, **k: ""))
+class RequestsStub(types.ModuleType):
+    def __init__(self):
+        super().__init__('requests')
+        self.packages = types.SimpleNamespace(urllib3=types.SimpleNamespace(disable_warnings=lambda *a, **k: None))
+
+sys.modules.setdefault('requests', RequestsStub())
+sys.modules.setdefault('application', types.ModuleType('application'))
+sys.modules.setdefault('application.controllers', types.ModuleType('application.controllers'))
+sys.modules.setdefault('application.controllers.ats_logger', types.SimpleNamespace(log_ats_data=lambda *a, **k: None))
+sys.modules.setdefault('dateutil', types.ModuleType('dateutil'))
+sys.modules.setdefault('dateutil.parser', types.SimpleNamespace())
+
+# Provide required environment variables
+os.environ.setdefault('INFLUXDB_PORT', '8086')
+os.environ.setdefault('MQTT_PORT', '1883')
+os.environ.setdefault('MQTT_BROKER_ADDRESS', 'localhost')
+os.environ.setdefault('MQTT_TOPIC', 'test')
+os.environ.setdefault('SECRET_KEY', 'secret')
+
+# Patch codecs.getwriter to avoid stdout replacement
+codecs.getwriter = lambda encoding: (lambda stream: stream)
+if hasattr(sys.stdout, "detach"):
+    sys.stdout.detach = lambda: sys.stdout
+
+import ast
+import types
+
+def load_app_utils():
+    mod = types.ModuleType('app_utils')
+    ns = mod.__dict__
+    src_path = os.path.join(os.path.dirname(__file__), '..', 'src', 'app.py')
+    with open(src_path) as f:
+        source = f.read()
+    tree = ast.parse(source)
+    ns['Path'] = __import__('pathlib').Path
+    ns['os'] = os
+    ns['BASE_DIR'] = __import__('pathlib').Path(os.path.join(os.path.dirname(src_path)))
+    ns['socket'] = socket
+    ns['json'] = json
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if getattr(target, 'id', '') == 'DATA_FILE':
+                    exec(compile(ast.Module([node], []), 'app', 'exec'), ns)
+        elif isinstance(node, ast.FunctionDef) and node.name in ('ping_device', 'count_online_offline_devices'):
+            exec(compile(ast.Module([node], []), 'app', 'exec'), ns)
+    sys.modules['app_utils'] = mod
+    return mod
+
+app_utils = load_app_utils()
+ping_device = app_utils.ping_device
+count_online_offline_devices = app_utils.count_online_offline_devices
+
+class DummySocket:
+    def close(self):
+        pass
+
+
+def test_ping_device_online(monkeypatch):
+    monkeypatch.setattr(socket, 'create_connection', lambda *a, **kw: DummySocket())
+    assert ping_device('1.1.1.1') is True
+
+def test_ping_device_offline(monkeypatch):
+    def raise_timeout(*a, **kw):
+        raise socket.timeout
+    monkeypatch.setattr(socket, 'create_connection', raise_timeout)
+    assert ping_device('1.1.1.1') is False
+
+def test_count_online_offline_devices(monkeypatch, tmp_path):
+    data = {
+        "chipid": {
+            "c1": {"about": {"ip": "1"}},
+            "c2": {"about": {"ip": "2"}}
+        }
+    }
+    file_path = tmp_path / 'data_setup.json'
+    file_path.write_text(json.dumps(data))
+    monkeypatch.setattr(sys.modules[ping_device.__module__], 'DATA_FILE', str(file_path))
+    monkeypatch.setattr(sys.modules[ping_device.__module__], 'ping_device', lambda ip: ip == '1')
+    online, offline = count_online_offline_devices()
+    assert online == 1
+    assert offline == 1


### PR DESCRIPTION
## Summary
- add tests for data_processor.process_data
- cover MQTT on_message handler
- test ping_device and count_online_offline_devices utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685804336304832ba5312408f6fcb71b