### PR TITLE
Use .env for InfluxDB settings

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -38,7 +38,7 @@ from dotenv import load_dotenv
 ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif'}
 
 # Tải các biến môi trường từ file .env
-load_dotenv()
+load_dotenv(dotenv_path=Path(__file__).resolve().parents[1] / ".env")
 
 # Thiết lập thư mục gốc của dự án
 BASE_DIR = Path(os.getenv("TN4_BASE_DIR", Path(__file__).resolve().parent))

--- a/src/application/controllers/ats_logger.py
+++ b/src/application/controllers/ats_logger.py
@@ -2,16 +2,17 @@ from datetime import datetime, timezone, timedelta
 from influxdb import InfluxDBClient
 import os
 from dotenv import load_dotenv
+from pathlib import Path
 
 # Load environment variables from a .env file if present
-load_dotenv()
+load_dotenv(dotenv_path=Path(__file__).resolve().parents[1] / ".env")
 
 VN_TZ = timezone(timedelta(hours=7))  # Múi giờ Việt Nam
 
 def log_ats_data(data):
     try:
         client = InfluxDBClient(
-            host=os.getenv("INFLUXDB_HOST", "localhost"),
+            host=os.getenv("INFLUXDB_HOST"),
             port=int(os.getenv("INFLUXDB_PORT", 8086)),
             username=os.getenv("INFLUXDB_USERNAME"),
             password=os.getenv("INFLUXDB_PASSWORD"),

--- a/src/influx_config.py
+++ b/src/influx_config.py
@@ -2,11 +2,12 @@
 from influxdb import InfluxDBClient
 import os
 from dotenv import load_dotenv
+from pathlib import Path
 
-load_dotenv()
+load_dotenv(dotenv_path=Path(__file__).resolve().parents[1] / ".env")
 
 client = InfluxDBClient(
-    host=os.getenv("INFLUXDB_HOST", "localhost"),
+    host=os.getenv("INFLUXDB_HOST"),
     port=int(os.getenv("INFLUXDB_PORT", 8086)),
     username=os.getenv("INFLUXDB_USERNAME"),
     password=os.getenv("INFLUXDB_PASSWORD"),


### PR DESCRIPTION
## Summary
- load `.env` from the project root
- rely on environment variables for InfluxDB host setting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68580ff10dfc832baef91add75c43193