### PR TITLE
Fix dotenv load path

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -38,7 +38,7 @@ from dotenv import load_dotenv
 ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif'}
 
 # Tải các biến môi trường từ file .env
-load_dotenv(dotenv_path=Path(__file__).resolve().parents[1] / ".env")
+load_dotenv(dotenv_path=Path(__file__).resolve().parent / ".env")
 
 # Thiết lập thư mục gốc của dự án
 BASE_DIR = Path(os.getenv("TN4_BASE_DIR", Path(__file__).resolve().parent))

--- a/src/application/controllers/ats_logger.py
+++ b/src/application/controllers/ats_logger.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 from pathlib import Path
 
 # Load environment variables from a .env file if present
-load_dotenv(dotenv_path=Path(__file__).resolve().parents[1] / ".env")
+load_dotenv(dotenv_path=Path(__file__).resolve().parent / ".env")
 
 VN_TZ = timezone(timedelta(hours=7))  # Múi giờ Việt Nam
 

--- a/src/influx_config.py
+++ b/src/influx_config.py
@@ -4,7 +4,7 @@ import os
 from dotenv import load_dotenv
 from pathlib import Path
 
-load_dotenv(dotenv_path=Path(__file__).resolve().parents[1] / ".env")
+load_dotenv(dotenv_path=Path(__file__).resolve().parent / ".env")
 
 client = InfluxDBClient(
     host=os.getenv("INFLUXDB_HOST"),


### PR DESCRIPTION
## Summary
- load `.env` from current directory instead of repo root
- keep `.env` committed at `src/.env`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685815c9cd54832b86d2c69478c4cdb2