### PR TITLE
Add Dockerfile and container docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Ignore Python virtual environments and caches
+venv/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Ignore tests and development files
+tests/
+scripts/
+.cache/
+*.log
+
+# Ignore git files
+.git
+.gitignore
+
+# Temporary directories
+tmp/
+temp/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY src ./src
+COPY database ./database
+
+# Default environment variables
+ENV SECRET_KEY=4s$eJ#8dLpRtYkMnCbV2gX1fA3h \
+    INFLUXDB_HOST=10.16.40.138 \
+    INFLUXDB_PORT=8086 \
+    INFLUXDB_USERNAME=cico \
+    INFLUXDB_PASSWORD=2020@GreenFeed \
+    INFLUXDB_DATABASE=ats_data \
+    MQTT_BROKER_ADDRESS=10.16.40.138 \
+    MQTT_PORT=1883 \
+    MQTT_TOPIC=PLC/LOGO/+ \
+    API_URL=http://10.50.41.18:58185/api/Farm/postbiohistory \
+    API_URL_CICO=https://10.50.41.18:58187/api/Farm/postbiohistory \
+    MQTT_BROKER_ADDRESS_MQTT=10.16.40.138 \
+    MQTT_PORT_MQTT=1883 \
+    MQTT_BROKER_ADDRESS_ATS=10.16.40.138 \
+    MQTT_PORT_ATS=1883 \
+    PLC_WATER_IP=10.16.40.160
+
+EXPOSE 58888
+
+CMD ["python", "src/app.py"]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Dự án **TN4** được phát triển nhằm thu thập và xử lý dữ li�
 
 Kích hoạt môi trường ảo (nếu chưa), sau đó chạy:
 ```bash
-python TN4/app.py
+python src/app.py
 ```
 Ứng dụng sẽ khởi động tại địa chỉ `http://localhost:58888` ở chế độ mặc định.
 
@@ -32,7 +32,7 @@ Ví dụ:
 
 ```bash
 export TN4_BASE_DIR=/opt/tn4/src
-python TN4/app.py
+python src/app.py
 ```
 
 ### Cấu hình `SECRET_KEY`
@@ -45,7 +45,16 @@ Ví dụ:
 
 ```bash
 export SECRET_KEY=mysecretkey
-python TN4/app.py
+python src/app.py
+```
+
+### Chạy bằng Docker
+
+Bạn có thể chạy ứng dụng mà không cần cài đặt Python thủ công bằng cách sử dụng Docker:
+
+```bash
+docker build -t tn4-app .
+docker run -p 58888:58888 --env-file src/.env tn4-app
 ```
 
 ## Cấu trúc thư mục chính


### PR DESCRIPTION
## Summary
- add Dockerfile to run the app with Python 3.9-slim
- ignore development folders with `.dockerignore`
- document Docker usage and update script paths in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68589bab2aa0832b9ea1acb834829f18