### PR TITLE
Remove dataclasses dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ certifi==2025.4.26
 charset-normalizer==2.0.12
 click==8.0.4
 Cython==3.0.12
-dataclasses==0.8
 distro==1.9.0
 dnspython==2.2.1
 eventlet==0.33.3


### PR DESCRIPTION
## Summary
- delete the `dataclasses` backport from requirements

## Testing
- `pytest -q`
- `docker build -t test .` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6858cc42c85c832ba24a4efe0fd52f0c