### PR TITLE
Fix Dockerfile secret quoting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY src ./src
 COPY database ./database
 
 # Default environment variables
-ENV SECRET_KEY=4s$eJ#8dLpRtYkMnCbV2gX1fA3h \
+ENV SECRET_KEY="4s\$eJ#8dLpRtYkMnCbV2gX1fA3h" \
     INFLUXDB_HOST=10.16.40.138 \
     INFLUXDB_PORT=8086 \
     INFLUXDB_USERNAME=cico \


### PR DESCRIPTION
## Summary
- quote `SECRET_KEY` in Dockerfile to prevent shell expansion

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858ccf957c8832bbc9ae31ca166d740