### PR TITLE
Remove pkg_resources from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ numpy==1.19.4
 packaging==21.3
 paho-mqtt==1.6.1
 Pillow==8.4.0
-pkg_resources==0.0.0
 pymodbus==2.5.3
 pyparsing==3.1.4
 pyserial==3.5


### PR DESCRIPTION
## Summary
- remove unused `pkg_resources` from `requirements.txt`

## Testing
- `docker build -t tn4-app .` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858cffb9fa8832bb6f523416e1e2877