### PR TITLE
Update dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,3 +22,5 @@ temp/
 # Ignore environment files
 src/.env
 
+src/static/dashboard/vendors/
+.cache/


### PR DESCRIPTION
## Summary
- ignore dashboard vendors directory when building container
- append .cache directory to dockerignore

## Testing
- `pytest -q`
- `docker build -t tn4test .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6858e4ea5afc832ba3b318a01089d5a4