### PR TITLE
Fix TypeError on Python 3.9

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -18,6 +18,7 @@ import logging
 import data_processor
 import paho.mqtt.client as mqtt
 from config import Config
+from typing import Optional
 from application.controllers.ats_logger import log_ats_data
 from logging import Formatter, StreamHandler
 from logging.handlers import TimedRotatingFileHandler
@@ -42,7 +43,7 @@ load_dotenv(dotenv_path=Path(__file__).resolve().parent / ".env")
 BASE_DIR = Path(os.getenv("TN4_BASE_DIR", Path(__file__).resolve().parent))
 
 
-def get_env_port(name: str, default: int | None = None) -> int:
+def get_env_port(name: str, default: Optional[int] = None) -> int:
     """Return integer port from environment or default."""
     value = os.getenv(name)
     if value is None:


### PR DESCRIPTION
## Summary
- use `typing.Optional` for `get_env_port`

## Testing
- `python` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593c5014a8832bb52e8e91325b5607