### PR TITLE
Fix duplicate flash message IDs

### DIFF
--- a/src/templates/ats/ats.html
+++ b/src/templates/ats/ats.html
@@ -220,7 +220,6 @@
 
           </div>
           <!-- <div class="text-center text-danger fw-bold mt-1" id="status1"></div> -->
-          <div class="text-center fw-bold mt-2" id="flash-message-1" style="display:none;"></div>
 
         </div>
       </div>
@@ -318,7 +317,6 @@
 
           </div>
           <!-- <div class="text-center text-danger fw-bold mt-1" id="status2"></div> -->
-          <div class="text-center fw-bold mt-2" id="flash-message-2" style="display:none;"></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- clean up duplicate `flash-message-1` and `flash-message-2` ids

## Testing
- `pytest -q` *(fails: NameError: name 'Optional' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68597866ab1c832bba31bf703f85f5f3