### PR TITLE
Show SELEC readings

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -18,7 +18,6 @@ import logging
 import data_processor
 import paho.mqtt.client as mqtt
 from config import Config
-from typing import Optional
 from application.controllers.ats_logger import log_ats_data
 from logging import Formatter, StreamHandler
 from logging.handlers import TimedRotatingFileHandler
@@ -43,7 +42,7 @@ load_dotenv(dotenv_path=Path(__file__).resolve().parent / ".env")
 BASE_DIR = Path(os.getenv("TN4_BASE_DIR", Path(__file__).resolve().parent))
 
 
-def get_env_port(name: str, default: Optional[int] = None) -> int:
+def get_env_port(name: str, default: int | None = None) -> int:
     """Return integer port from environment or default."""
     value = os.getenv(name)
     if value is None:

--- a/src/application/controllers/ats_logger.py
+++ b/src/application/controllers/ats_logger.py
@@ -37,7 +37,9 @@ FIELD_MAP = {
     'r23': 'status_close_a',
     'r24': 'status_close_b',
     'r25': 'status_open',
-    'r26': 'auto_mode'
+    'r26': 'auto_mode',
+    'r27': 'selec1',
+    'r28': 'selec2'
 }
 
 def log_ats_data(data):

--- a/src/ats_socket.py
+++ b/src/ats_socket.py
@@ -38,7 +38,9 @@ FIELD_MAP = {
     'r23': 'status_close_a',
     'r24': 'status_close_b',
     'r25': 'status_open',
-    'r26': 'auto_mode'
+    'r26': 'auto_mode',
+    'r27': 'selec1',
+    'r28': 'selec2'
 }
 
 def map_generator_fields(gen_data: dict) -> dict:
@@ -69,6 +71,11 @@ def on_message(client, userdata, msg):
             for gen_key in ["gen1", "gen2"]:
                 if gen_key in data:
                     mapped[gen_key] = map_generator_fields(data[gen_key])
+
+            # Lấy thêm các giá trị SELEC nếu có
+            for field in ["selec1", "selec2"]:
+                if field in data:
+                    mapped[field] = data[field]
 
             # 🔴 Ghi dữ liệu điện năng vào InfluxDB
             log_ats_data(mapped)

--- a/src/templates/ats/ats.html
+++ b/src/templates/ats/ats.html
@@ -480,6 +480,15 @@
       </div>
     </div>
 
+    <!-- Vùng hiển thị chỉ số SELEC -->
+    <div class="card mt-3">
+      <div class="card-header">Chỉ số SELEC</div>
+      <div class="card-body">
+        <p><strong>SELEC 1:</strong> <span id="selec1">--</span></p>
+        <p><strong>SELEC 2:</strong> <span id="selec2">--</span></p>
+      </div>
+    </div>
+
     <div class="row mb-3">
       <a href="{{ url_for('Home') }}" class="btn btn-secondary">Back to Dashboard</a>
       <!-- Bổ sung HTML hiển thị số lượng client trong thẻ tiêu đề -->
@@ -518,6 +527,10 @@
       console.log("📦 Nhận từ socket:", data);
       updateData("gen1", data.gen1);
       updateData("gen2", data.gen2);
+      const sel1El = document.getElementById("selec1");
+      const sel2El = document.getElementById("selec2");
+      if (sel1El && typeof data.selec1 !== "undefined") sel1El.textContent = data.selec1;
+      if (sel2El && typeof data.selec2 !== "undefined") sel2El.textContent = data.selec2;
       updateChart(chartGen1, data.gen1.ia, data.gen1.ib, data.gen1.ic);
       updateChart(chartGen2, data.gen2.ia, data.gen2.ib, data.gen2.ic);
       const now = new Date().toLocaleTimeString('vi-VN', { hour12: false });


### PR DESCRIPTION
## Summary
- map `selec1` and `selec2` from MQTT data
- display SELEC values on ATS page and update via Socket.IO
- adjust `get_env_port` annotation for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685979a91020832b99b709f8dd9cd883