### PR TITLE
Enable blinking effect in ATS dashboard

### DIFF
--- a/src/templates/ats/ats.html
+++ b/src/templates/ats/ats.html
@@ -588,6 +588,11 @@
           }
         }
 
+        // Thêm hiệu ứng nhấp nháy nếu có hàm hỗ trợ
+        if (typeof setBlinkingStyle === 'function') {
+          setBlinkingStyle(el, newValue, current, key);
+        }
+
         el.textContent = newValue;
       }
 


### PR DESCRIPTION
## Summary
- call `setBlinkingStyle` when updating ATS metrics
- keep blinking style function active

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68597bde7394832b9da49b35155be502