### PR TITLE
Fix union type for Python 3.9 compatibility

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -42,7 +42,7 @@ load_dotenv(dotenv_path=Path(__file__).resolve().parent / ".env")
 BASE_DIR = Path(os.getenv("TN4_BASE_DIR", Path(__file__).resolve().parent))
 
 
-def get_env_port(name: str, default: int | None = None) -> int:
+def get_env_port(name: str, default: "int | None" = None) -> int:
     """Return integer port from environment or default."""
     value = os.getenv(name)
     if value is None:


### PR DESCRIPTION
## Summary
- use string type hint in `get_env_port` so app works under Python 3.9

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685976eab100832baa54efc5eb02c5bb