### PR TITLE
Add UTF-8 encoding to log handlers

### DIFF
--- a/scripts/examples/service_update.py
+++ b/scripts/examples/service_update.py
@@ -22,7 +22,9 @@ stream_handler.setFormatter(formatter)
 logger.addHandler(stream_handler)
 
 # Split log at 0h everyday
-file_handler = TimedRotatingFileHandler('./database/log/log_cico_everyday.log', when="midnight", interval=1)
+file_handler = TimedRotatingFileHandler(
+    './database/log/log_cico_everyday.log', when="midnight", interval=1, encoding="utf-8"
+)
 file_handler.setFormatter(formatter)
 file_handler.setLevel(logging.DEBUG)
 logger.addHandler(file_handler)

--- a/scripts/examples/services.py
+++ b/scripts/examples/services.py
@@ -36,7 +36,9 @@ stream_handler.setFormatter(formatter)
 logger.addHandler(stream_handler)
 
 # Split log at 0h everyday
-file_handler = TimedRotatingFileHandler('./database/log/log_cico_everyday.log', when="midnight", interval=1)
+file_handler = TimedRotatingFileHandler(
+    './database/log/log_cico_everyday.log', when="midnight", interval=1, encoding="utf-8"
+)
 file_handler.setFormatter(formatter)
 file_handler.setLevel(logging.DEBUG)
 logger.addHandler(file_handler)

--- a/scripts/examples/services_script.py
+++ b/scripts/examples/services_script.py
@@ -36,7 +36,9 @@ stream_handler.setFormatter(formatter)
 logger.addHandler(stream_handler)
 
 # Split log at 0h everyday
-file_handler = TimedRotatingFileHandler('./database/log/log_cico_everyday.log', when="midnight", interval=1)
+file_handler = TimedRotatingFileHandler(
+    './database/log/log_cico_everyday.log', when="midnight", interval=1, encoding="utf-8"
+)
 file_handler.setFormatter(formatter)
 file_handler.setLevel(logging.DEBUG)
 logger.addHandler(file_handler)

--- a/src/app.py
+++ b/src/app.py
@@ -109,7 +109,9 @@ logger.addHandler(stream_handler)
 # File handler (log file, split at midnight everyday)
 log_dir = BASE_DIR / "database" / "log"
 os.makedirs(log_dir, exist_ok=True)
-file_handler = TimedRotatingFileHandler(str(log_dir / "log_cico_everyday.log"), when="midnight", interval=1)
+file_handler = TimedRotatingFileHandler(
+    str(log_dir / "log_cico_everyday.log"), when="midnight", interval=1, encoding="utf-8"
+)
 file_handler.setFormatter(formatter)
 file_handler.setLevel(logging.DEBUG)
 logger.addHandler(file_handler)


### PR DESCRIPTION
## Summary
- set `encoding="utf-8"` when creating `TimedRotatingFileHandler` in `src/app.py`
- do the same in example service scripts to avoid UnicodeEncodeError on Windows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d6b6bedd4832b8b70684b4c5d1d10