### PR TITLE
Allow custom ATS history time range

### DIFF
--- a/src/templates/ats/ats.html
+++ b/src/templates/ats/ats.html
@@ -328,23 +328,23 @@
           <h5 class="text-primary">Biểu đồ dòng điện</h5>
 
           <div class="row mb-3">
-            <div class="col-md-4">
+            <div class="col-md-3">
               <label for="genSelect" class="form-label">Chọn nguồn:</label>
               <select id="genSelect" class="form-select">
                 <option value="1" selected>NGUỒN 1</option>
                 <option value="2">NGUỒN 2</option>
               </select>
             </div>
-            <div class="col-md-4">
-              <label for="rangeSelect" class="form-label">Khoảng thời gian:</label>
-              <select id="rangeSelect" class="form-select">
-                <option value="1h">1 Giờ</option>
-                <option value="3h">3 Giờ</option>
-                <option value="6h">6 Giờ</option>
-                <option value="9h">9 Giờ</option>
-                <option value="12h">12 Giờ</option>
-                <option value="24h" selected>24 Giờ</option>
-              </select>
+            <div class="col-md-3">
+              <label for="startTime" class="form-label">Từ:</label>
+              <input type="datetime-local" id="startTime" class="form-control">
+            </div>
+            <div class="col-md-3">
+              <label for="endTime" class="form-label">Đến:</label>
+              <input type="datetime-local" id="endTime" class="form-control">
+            </div>
+            <div class="col-md-3 d-flex align-items-end">
+              <button id="loadHistoryBtn" class="btn btn-primary w-100">Tải dữ liệu</button>
             </div>
 
           </div>
@@ -439,11 +439,10 @@
       });
 
 
-      function loadHistoryRange(genId = 1, range = "1d") {
-        fetch(`/api/ats/history/${genId}?range=${range}`)
+      function loadHistory(genId = 1, start, end) {
+        fetch(`/api/ats/history/${genId}?start=${encodeURIComponent(start)}&end=${encodeURIComponent(end)}`)
           .then(res => res.json())
           .then(data => {
-            // Chuyển UTC sang giờ VN (+7) và định dạng
             historyChart.data.labels = data.map(d => new Date(d.time));
             historyChart.data.datasets[0].data = data.map(d => d.ia);
             historyChart.data.datasets[1].data = data.map(d => d.ib);
@@ -453,20 +452,31 @@
           .catch(err => console.error("Lỗi khi tải dữ liệu lịch sử:", err));
       }
 
-      // Mặc định tải ATS 1 trong 1 ngày
-      loadHistoryRange(1, "1d");
+      function toDatetimeLocal(date) {
+        const offset = date.getTimezoneOffset();
+        const local = new Date(date.getTime() - offset * 60000);
+        return local.toISOString().slice(0, 16);
+      }
 
-      document.getElementById("rangeSelect").addEventListener("change", () => {
-        const genId = document.getElementById("genSelect").value;
-        const range = document.getElementById("rangeSelect").value;
-        loadHistoryRange(genId, range);
-      });
+      const startInput = document.getElementById("startTime");
+      const endInput = document.getElementById("endTime");
+      const genSelect = document.getElementById("genSelect");
+      const loadBtn = document.getElementById("loadHistoryBtn");
 
-      document.getElementById("genSelect").addEventListener("change", () => {
-        const genId = document.getElementById("genSelect").value;
-        const range = document.getElementById("rangeSelect").value;
-        loadHistoryRange(genId, range);
-      });
+      const now = new Date();
+      endInput.value = toDatetimeLocal(now);
+      startInput.value = toDatetimeLocal(new Date(now.getTime() - 24 * 60 * 60 * 1000));
+      loadHistory(1, startInput.value, endInput.value);
+
+      function triggerLoad() {
+        const genId = genSelect.value;
+        loadHistory(genId, startInput.value, endInput.value);
+      }
+
+      loadBtn.addEventListener("click", triggerLoad);
+      genSelect.addEventListener("change", triggerLoad);
+      startInput.addEventListener("change", triggerLoad);
+      endInput.addEventListener("change", triggerLoad);
     </script>
     <!-- end test -->
 

--- a/tests/test_ats_history.py
+++ b/tests/test_ats_history.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import types
+from datetime import datetime
+
+# Ensure src is on path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+# Import test_utils for stubs and env vars
+from tests import test_utils  # noqa: F401
+
+# Ensure the Flask stub provides context_processor
+def make_flask(*a, **k):
+    class DummyFlask(types.SimpleNamespace):
+        def route(self, *args, **kwargs):
+            def decorator(f):
+                return f
+            return decorator
+
+        def context_processor(self, func=None):
+            def decorator(f):
+                return f
+            return decorator(func) if func else decorator
+    return DummyFlask()
+
+test_utils.sys.modules['flask'].Flask = make_flask
+test_utils.sys.modules['requests'].post = lambda *a, **k: None
+
+import app
+
+class DummyResult:
+    def __init__(self):
+        self._points = [{"time": "2024-01-01T00:00:00Z", "ia": 1, "ib": 2, "ic": 3}]
+    def get_points(self):
+        return self._points
+
+class DummyClient:
+    def __init__(self):
+        self.queries = []
+    def query(self, q):
+        self.queries.append(q)
+        return DummyResult()
+
+
+def test_get_history_start_end(monkeypatch):
+    dummy = DummyClient()
+    monkeypatch.setattr(app, 'InfluxDBClient', lambda *a, **k: dummy)
+    monkeypatch.setattr(app, 'parser', types.SimpleNamespace(parse=lambda s: datetime.fromisoformat(s)))
+    monkeypatch.setattr(app, 'jsonify', lambda x: x)
+    app.request = types.SimpleNamespace(args={
+        'start': '2024-01-01T07:00',
+        'end': '2024-01-01T08:00'
+    })
+    result = app.get_ats_history(1)
+    assert dummy.queries
+    q = dummy.queries[0]
+    assert 'time >=' in q and 'time <=' in q
+    assert result[0]['ia'] == 1
+    assert result[0]['time'].endswith('+07:00')


### PR DESCRIPTION
## Summary
- replace range dropdown with start/end datetime inputs
- fetch ATS history by explicit start/end times
- support `start` and `end` params in backend API
- test new history logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68628fe40f14832baa3a92b140c0cc0e