### PR TITLE
Add optional MQTT auth config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ export SECRET_KEY=mysecretkey
 python src/app.py
 ```
 
+### Cấu hình MQTT Username và Password
+
+Khi broker yêu cầu xác thực, bạn có thể cung cấp thông tin đăng nhập qua
+hai biến môi trường `MQTT_USERNAME` và `MQTT_PASSWORD`.
+
+Ví dụ:
+
+```bash
+export MQTT_USERNAME=user
+export MQTT_PASSWORD=pass
+python src/app.py
+```
+
 ### Tạo file `.env`
 
 Sao chép `src/.env.example` thành `src/.env` và thay đổi các giá trị phù hợp.
@@ -62,6 +75,8 @@ INFLUXDB_PASSWORD={PASS}
 MQTT_BROKER_ADDRESS=127.0.0.1
 MQTT_PORT=1883
 MQTT_TOPIC=tn4/data
+MQTT_USERNAME=youruser
+MQTT_PASSWORD=yourpass
 MQTT_BROKER_ADDRESS_ATS=127.0.0.1
 MQTT_PORT_ATS=1883
 USER_FILE=./database/data_setup/users.json

--- a/src/app.py
+++ b/src/app.py
@@ -87,6 +87,8 @@ database = os.getenv("INFLUXDB_DATABASE", "ats_data")
 BROKER_ADDRESS = os.getenv("MQTT_BROKER_ADDRESS")
 PORT = get_env_port("MQTT_PORT", default=1883)
 TOPIC = os.getenv("MQTT_TOPIC")
+MQTT_USERNAME = os.getenv("MQTT_USERNAME")
+MQTT_PASSWORD = os.getenv("MQTT_PASSWORD")
 
 # Track MQTT connection state so we only log successful connection once
 mqtt_connected = False
@@ -316,6 +318,8 @@ mqtt_client.on_disconnect = on_disconnect
 def start_mqtt_loop():
     try:
         logger.info("Đang kết nối đến MQTT broker...")
+        if MQTT_USERNAME and MQTT_PASSWORD:
+            mqtt_client.username_pw_set(MQTT_USERNAME, MQTT_PASSWORD)
         mqtt_client.connect(BROKER_ADDRESS, PORT)
         # Slow down reconnection attempts
         mqtt_client.reconnect_delay_set(min_delay=5, max_delay=60)

--- a/tests/test_mqtt_auth.py
+++ b/tests/test_mqtt_auth.py
@@ -1,0 +1,23 @@
+from tests import test_utils  # noqa: F401 - set up stubs and env vars
+import app
+
+class DummyMQTT:
+    def __init__(self):
+        self.username_pw = None
+        self.connected = False
+    def username_pw_set(self, username, password):
+        self.username_pw = (username, password)
+    def connect(self, *a, **k):
+        self.connected = True
+    def reconnect_delay_set(self, *a, **k):
+        pass
+    def loop_forever(self):
+        pass
+
+def test_start_mqtt_loop_uses_credentials(monkeypatch):
+    dummy = DummyMQTT()
+    monkeypatch.setattr(app, "mqtt_client", dummy)
+    monkeypatch.setattr(app, "MQTT_USERNAME", "user")
+    monkeypatch.setattr(app, "MQTT_PASSWORD", "pass")
+    app.start_mqtt_loop()
+    assert dummy.username_pw == ("user", "pass")


### PR DESCRIPTION
## Summary
- read `MQTT_USERNAME` and `MQTT_PASSWORD` from environment
- use them in `start_mqtt_loop()` when both provided
- document new variables in README
- test that credentials are passed to the MQTT client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cae33e3c4832baee2fe649efc2581