### PR TITLE
Use TN4_BASE_DIR in data processor

### DIFF
--- a/src/data_processor.py
+++ b/src/data_processor.py
@@ -5,6 +5,7 @@ import json
 from urllib3.exceptions import InsecureRequestWarning
 import requests
 import base64
+from pathlib import Path
 # from app import logger, uv_data
 # Tắt cảnh báo liên quan đến SSL
 # http = urllib3.PoolManager()
@@ -13,8 +14,9 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 # API chính
 url = os.getenv("API_URL")
 url_cico = os.getenv("API_URL_CICO")
-link = "./database/data_setup/"
-file = "data_setup.json"
+
+# Thiết lập thư mục gốc của dự án tương tự như app.py
+BASE_DIR = Path(os.getenv("TN4_BASE_DIR", Path(__file__).resolve().parent))
 
 
 
@@ -28,7 +30,8 @@ def process_data(data):
     api_data = json.dumps(data, ensure_ascii=False, indent=4)
 
     # Đọc dữ liệu từ file JSON
-    with open(link + file, "r", encoding='utf-8') as fin:
+    data_setup_path = BASE_DIR / "database" / "data_setup" / "data_setup.json"
+    with open(data_setup_path, "r", encoding="utf-8") as fin:
         data_json = json.load(fin)
 
     # Chuyển chuỗi JSON thành từ điển
@@ -93,7 +96,7 @@ def process_data(data):
                 if 'ip' in about_data and 'version' in about_data:
                     about_data['ip'] = ip
                     about_data['version'] = version
-                    with open(link + file, 'w', encoding='utf-8') as fout:
+                    with open(data_setup_path, "w", encoding="utf-8") as fout:
                         json.dump(data_json, fout, ensure_ascii=False, indent=4)
                     logger.critical('Đã cập nhật dữ liệu about: %s', api_value)
                 else:

--- a/tests/test_data_processor.py
+++ b/tests/test_data_processor.py
@@ -47,14 +47,15 @@ def setup_tmp_json(tmp_path):
             }
         }
     }
-    path = tmp_path / "data_setup.json"
-    path.write_text(json.dumps(data))
-    return path
+    dir_path = tmp_path / "database" / "data_setup"
+    dir_path.mkdir(parents=True, exist_ok=True)
+    file_path = dir_path / "data_setup.json"
+    file_path.write_text(json.dumps(data))
+    return file_path
 
 def test_process_data_success(monkeypatch, tmp_path):
     json_path = setup_tmp_json(tmp_path)
-    monkeypatch.setattr(data_processor, "link", str(tmp_path) + "/")
-    monkeypatch.setattr(data_processor, "file", "data_setup.json")
+    monkeypatch.setattr(data_processor, "BASE_DIR", tmp_path)
     monkeypatch.setattr(data_processor.cv2, "VideoCapture", lambda cam: DummyCap())
     monkeypatch.setattr(data_processor.cv2, "imencode", lambda ext, img: (True, b"img"))
     monkeypatch.setattr(data_processor.requests, "post", lambda *a, **kw: DummyResponse())
@@ -69,8 +70,7 @@ def test_process_data_success(monkeypatch, tmp_path):
 
 def test_process_data_invalid_id(monkeypatch, tmp_path):
     setup_tmp_json(tmp_path)
-    monkeypatch.setattr(data_processor, "link", str(tmp_path) + "/")
-    monkeypatch.setattr(data_processor, "file", "data_setup.json")
+    monkeypatch.setattr(data_processor, "BASE_DIR", tmp_path)
 
     data = {"idchip": "unknown", "name": "uv1", "status": "start", "ip": "1", "version": "v"}
     result = data_processor.process_data(data)


### PR DESCRIPTION
## Summary
- compute `BASE_DIR` in `data_processor` like `app.py`
- load and save the JSON file using `BASE_DIR / database/data_setup/data_setup.json`
- adjust tests to patch `BASE_DIR` instead of `link`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cb156e648832b8a6c62f804bc2154