### PR TITLE
Improve MQTT bad credential handling

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -208,6 +208,11 @@ def on_connect(client, userdata, flags, rc):
             logger.info("Đã kết nối với MQTT Broker! app.py")
         mqtt_connected = True
         client.subscribe(TOPIC)  # Đăng ký topic với ký tự đại diện
+    elif rc == 7:
+        logger.error(
+            "MQTT connection refused: bad credentials "
+            "(check MQTT_USERNAME/MQTT_PASSWORD)"
+        )
     else:
         logger.warning(f"Failed to connect, return code {rc}")
 
@@ -215,7 +220,13 @@ def on_connect(client, userdata, flags, rc):
 def on_disconnect(client, userdata, rc):
     global mqtt_connected
     mqtt_connected = False
-    logger.warning(f"MQTT disconnected with reason code {rc}")
+    if rc == 7:
+        logger.error(
+            "MQTT disconnected: bad credentials "
+            "(check MQTT_USERNAME/MQTT_PASSWORD)"
+        )
+    else:
+        logger.warning(f"MQTT disconnected with reason code {rc}")
 
 # Hàm callback khi nhận được tin nhắn từ MQTT
 # Hàm callback khi nhận được tin nhắn từ MQTT

--- a/tests/test_mqtt_connection.py
+++ b/tests/test_mqtt_connection.py
@@ -34,3 +34,27 @@ def test_on_connect_logs_once(caplog):
     app.on_connect(client, None, None, 0)
     logs = [r.message for r in caplog.records if "Đã kết nối" in r.message]
     assert len(logs) == 1
+
+
+def test_on_connect_bad_credentials(caplog):
+    client = DummyClient()
+    caplog.set_level(logging.ERROR)
+
+    app.on_connect(client, None, None, 7)
+
+    msgs = [r.message for r in caplog.records]
+    joined = "\n".join(msgs)
+    assert "bad credentials" in joined
+    assert "MQTT_USERNAME" in joined
+    assert "MQTT_PASSWORD" in joined
+
+
+def test_on_disconnect_bad_credentials(caplog):
+    client = DummyClient()
+    caplog.set_level(logging.ERROR)
+
+    app.on_disconnect(client, None, 7)
+
+    msgs = [r.message for r in caplog.records]
+    joined = "\n".join(msgs)
+    assert "bad credentials" in joined


### PR DESCRIPTION
## Summary
- handle MQTT reason code 7 as bad credentials in `on_connect` and `on_disconnect`
- log helpful messages referencing `MQTT_USERNAME` and `MQTT_PASSWORD`
- add tests for the new log messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cbf47a13c832ba30d75ec3fa04f6f