### PR TITLE
Add OTA firmware upload page

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -35,11 +35,16 @@ from dotenv import load_dotenv
 # Các định dạng ảnh cho phép upload
 ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif'}
 
+
 # Tải các biến môi trường từ file .env
 load_dotenv(dotenv_path=Path(__file__).resolve().parent / ".env")
 
 # Thiết lập thư mục gốc của dự án
 BASE_DIR = Path(os.getenv("TN4_BASE_DIR", Path(__file__).resolve().parent))
+
+# Thư mục và định dạng firmware cho tính năng OTA
+FIRMWARE_DIR = BASE_DIR / "firmware"
+ALLOWED_FIRMWARE_EXTENSIONS = {'bin'}
 
 
 def get_env_port(name: str, default: "int | None" = None) -> int:
@@ -1161,6 +1166,11 @@ def access_history_partial():
 
 def allowed_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+
+def allowed_firmware_file(filename: str) -> bool:
+    """Kiểm tra phần mở rộng tệp firmware hợp lệ."""
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_FIRMWARE_EXTENSIONS
 @app.route('/profile')
 def profile():
     if not session.get('logged_in'):
@@ -1230,6 +1240,37 @@ def change_password():
         flash('Mật khẩu cũ không đúng.')
 
     return redirect(url_for('profile'))
+
+
+@app.route('/firmware/upload', methods=['GET', 'POST'])
+def upload_firmware():
+    """Trang tải lên firmware cho thiết bị ESP."""
+    if not session.get('logged_in'):
+        return redirect(url_for('login'))
+
+    if request.method == 'POST':
+        file = request.files.get('firmware')
+        if not file or file.filename == '':
+            flash('Chưa chọn file firmware.', 'danger')
+            return redirect(request.url)
+
+        if not allowed_firmware_file(file.filename):
+            flash('Định dạng firmware không hợp lệ.', 'danger')
+            return redirect(request.url)
+
+        os.makedirs(FIRMWARE_DIR, exist_ok=True)
+        filename = secure_filename(file.filename)
+        file.save(os.path.join(FIRMWARE_DIR, filename))
+        flash('Tải firmware thành công.', 'success')
+        return redirect(url_for('upload_firmware'))
+
+    return render_template('firmware_upload.html')
+
+
+@app.route('/firmware/files/<path:filename>')
+def firmware_files(filename):
+    """Phục vụ tệp firmware cho thiết bị."""
+    return send_from_directory(FIRMWARE_DIR, filename)
 @app.route('/api/get_device_realtime_data')
 def get_device_realtime_data():
     # Giả lập dữ liệu real-time cho các thiết bị

--- a/src/database/data_setup/permissions.json
+++ b/src/database/data_setup/permissions.json
@@ -35,6 +35,12 @@
         "label": "Lịch sử đăng nhập",
         "url": "/access_history",
         "icon": "fa fa-edit"
+      },
+      {
+        "permission": "firmware_update",
+        "label": "Cập nhật Firmware",
+        "url": "/firmware/upload",
+        "icon": "fa fa-upload"
       }
     ],
     "camera_menu": [

--- a/src/templates/firmware/firmware_upload.html
+++ b/src/templates/firmware/firmware_upload.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="page-title">
+  <div class="title_left">
+    <h3>Cập nhật Firmware</h3>
+  </div>
+</div>
+<div class="clearfix"></div>
+<div class="row">
+  <div class="col-md-6 col-sm-6 ">
+    <div class="x_panel">
+      <div class="x_title">
+        <h2>Tải lên tập tin</h2>
+        <div class="clearfix"></div>
+      </div>
+      <div class="x_content">
+        <form method="post" enctype="multipart/form-data">
+          <div class="form-group">
+            <input type="file" name="firmware" class="form-control" required>
+          </div>
+          <button type="submit" class="btn btn-success"><i class="fa fa-upload"></i> Upload</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -83,9 +83,11 @@ def load_app_utils():
     for node in tree.body:
         if isinstance(node, ast.Assign):
             for target in node.targets:
-                if getattr(target, 'id', '') == 'DATA_FILE':
+                if getattr(target, 'id', '') in (
+                    'DATA_FILE', 'ALLOWED_FIRMWARE_EXTENSIONS', 'FIRMWARE_DIR'):
                     exec(compile(ast.Module([node], []), 'app', 'exec'), ns)
-        elif isinstance(node, ast.FunctionDef) and node.name in ('ping_device', 'count_online_offline_devices', 'get_env_port'):
+        elif isinstance(node, ast.FunctionDef) and node.name in (
+            'ping_device', 'count_online_offline_devices', 'get_env_port', 'allowed_firmware_file'):
             exec(compile(ast.Module([node], []), 'app', 'exec'), ns)
     sys.modules['app_utils'] = mod
     return mod
@@ -94,6 +96,7 @@ app_utils = load_app_utils()
 ping_device = app_utils.ping_device
 count_online_offline_devices = app_utils.count_online_offline_devices
 get_env_port = app_utils.get_env_port
+allowed_firmware_file = app_utils.allowed_firmware_file
 
 class DummySocket:
     def close(self):
@@ -140,3 +143,8 @@ def test_get_env_port_raises(monkeypatch):
     monkeypatch.delenv('MISSING_PORT', raising=False)
     with pytest.raises(RuntimeError):
         get_env_port('MISSING_PORT')
+
+
+def test_allowed_firmware_file():
+    assert allowed_firmware_file('fw.bin') is True
+    assert allowed_firmware_file('fw.txt') is False


### PR DESCRIPTION
## Summary
- support firmware uploads for ESP devices
- provide endpoints and template to host firmware binaries
- expose firmware helper in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889ae456120832b8c5dbb603f8bcde7