### PR TITLE
Fix firmware upload template path

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1264,7 +1264,7 @@ def upload_firmware():
         flash('Tải firmware thành công.', 'success')
         return redirect(url_for('upload_firmware'))
 
-    return render_template('firmware_upload.html')
+    return render_template('firmware/firmware_upload.html')
 
 
 @app.route('/firmware/files/<path:filename>')


### PR DESCRIPTION
## Summary
- ensure firmware upload page uses proper subfolder path

## Testing
- `pytest -q`
- `python src/app.py` *(fails: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_6889bdbcb0b8832ba6450233be31a29e